### PR TITLE
fix runtime exceptions, skill execution blockers, and micro-optimize advancement routing

### DIFF
--- a/src/bot/actions.ts
+++ b/src/bot/actions.ts
@@ -71,7 +71,7 @@ async function executeActionInner(bot: Bot, action: string, params: Record<strin
       case "gather_wood":
         return await gatherWood(bot, params.count || 5);
       case "mine_block":
-        return await mineBlock(bot, params.blockType || DEFAULT_MINE_TARGET, params.protectPos);
+        return await mineBlock(bot, params.blockType || params.block || params.item || DEFAULT_MINE_TARGET, params.protectPos);
       case "go_to":
       case "navigate":
       case "navigate_to":
@@ -103,7 +103,7 @@ async function executeActionInner(bot: Bot, action: string, params: Record<strin
       case "build_shelter":
         return await buildShelter(bot);
       case "place_block":
-        return await placeBlock(bot, params.blockType);
+        return await placeBlock(bot, params.blockType || params.block || params.item);
       case "sleep":
       case "sleep_in_bed": // common LLM aliases for sleep
       case "use_bed":
@@ -1358,7 +1358,7 @@ async function attackNearest(bot: Bot): Promise<string> {
   if (!target) {
     // Last resort: any living mob nearby (exclude players, dropped items, projectiles)
     target = bot.nearestEntity(
-      (e) => e !== bot.entity && e.type === "mob" && e.position.distanceTo(bot.entity.position) < 8,
+      (e) => e !== bot.entity && !!e.position && e.type === "mob" && e.position.distanceTo(myPos) < 8,
     );
     if (!target) return "No hostiles or food animals to hunt nearby. Explore to find some.";
   }
@@ -1469,8 +1469,10 @@ async function huntAnimal(bot: Bot, animal: import("prismarine-entity").Entity):
 }
 
 async function flee(bot: Bot): Promise<string> {
+  const myPos = bot.entity?.position;
+  if (!myPos) return "Can't flee right now — still respawning.";
   // Use same hostile detection as perception system
-  const hostile = bot.nearestEntity((e) => isHostile(e) && e.position.distanceTo(bot.entity.position) < 16);
+  const hostile = bot.nearestEntity((e) => !!e.position && isHostile(e) && e.position.distanceTo(myPos) < 16);
 
   if (!hostile) {
     // No hostile found — just move somewhere random to break the loop

--- a/src/bot/advancement-tree.ts
+++ b/src/bot/advancement-tree.ts
@@ -51,6 +51,8 @@ for (const a of ALL_ADVANCEMENTS) {
   CHILDREN.set(a.parent, list);
 }
 
+const DESCENDANT_COUNTS = new Map<string, number>();
+
 /**
  * How many advancements this one eventually unlocks.
  *
@@ -60,8 +62,11 @@ for (const a of ALL_ADVANCEMENTS) {
  * portal stayed unbuilt.
  */
 export function descendantCount(id: string): number {
+  const cached = DESCENDANT_COUNTS.get(id);
+  if (cached !== undefined) return cached;
   let total = 0;
   for (const child of CHILDREN.get(id) ?? []) total += 1 + descendantCount(child);
+  DESCENDANT_COUNTS.set(id, total);
   return total;
 }
 

--- a/src/bot/brain.ts
+++ b/src/bot/brain.ts
@@ -475,11 +475,14 @@ export class BotBrain {
     if (this.processing || this.stopped) return;
     if (isSkillRunning(this.bot)) return; // Don't interrupt skills
 
+    const myPos = this.bot.entity?.position;
+    if (!myPos) return;
+
     const now = Date.now();
     if (now - this.lastReactiveMs < this.REACTIVE_COOLDOWN_MS) return;
 
     const hostiles = Object.values(this.bot.entities).filter(
-      (e) => e !== this.bot.entity && isHostile(e) && e.position.distanceTo(this.bot.entity.position) < 16,
+      (e) => e !== this.bot.entity && !!e.position && isHostile(e) && e.position.distanceTo(myPos) < 16,
     );
 
     if (hostiles.length === 0) return;

--- a/src/bot/perception.ts
+++ b/src/bot/perception.ts
@@ -108,13 +108,16 @@ export function getWorldContext(bot: Bot, role?: string): string {
 }
 
 function getNearbyEntities(bot: Bot, range: number): Entity[] {
+  if (!bot.entity?.position) return [];
   return Object.values(bot.entities).filter((e) => {
     if (e === bot.entity) return false;
+    if (!e.position) return false;
     return distTo(bot, e) <= range;
   });
 }
 
 function distTo(bot: Bot, entity: Entity): number {
+  if (!bot.entity?.position || !entity.position) return Infinity;
   return bot.entity.position.distanceTo(entity.position);
 }
 

--- a/src/bot/place-guard.ts
+++ b/src/bot/place-guard.ts
@@ -52,6 +52,7 @@ const FURNITURE = [
 export const FURNITURE_MAX_ABOVE_BASE = 16;
 
 export function isFurniture(blockType: string): boolean {
+  if (!blockType || typeof blockType !== "string") return false;
   return FURNITURE.some((f) => blockType === f || blockType.endsWith(`_${f}`));
 }
 

--- a/src/skills/build-house.ts
+++ b/src/skills/build-house.ts
@@ -20,6 +20,7 @@ const DOOR_TYPES = [
   "dark_oak_door",
   "cherry_door",
   "mangrove_door",
+  "pale_oak_door",
 ] as const;
 
 /** Remember last build site so repeated build_house calls finish the same house */

--- a/src/skills/craft-gear.ts
+++ b/src/skills/craft-gear.ts
@@ -188,7 +188,7 @@ export const craftGearSkill: Skill = {
         .items()
         .filter((i) => i.name === "iron_ingot")
         .reduce((sum, i) => sum + i.count, 0);
-      const owned = bot.inventory.items().map((i) => i.name);
+      const owned = bot.inventory.slots.filter(Boolean).map((i) => i.name);
       const piece = affordableArmourPiece(ingots, owned);
       if (piece) {
         console.log(`[GearDebug] armour: ${ingots} ingots -> attempting ${piece}`);

--- a/src/skills/fill-bucket.ts
+++ b/src/skills/fill-bucket.ts
@@ -102,8 +102,8 @@ export const fillBucketSkill: Skill = {
     fluid: { type: "string", description: '"lava" or "water" — defaults to lava' },
   },
 
-  estimateMaterials() {
-    return { bucket: 1 };
+  estimateMaterials(_bot, _params) {
+    return {};
   },
 
   async execute(bot, params): Promise<SkillResult> {

--- a/src/skills/nether-portal.ts
+++ b/src/skills/nether-portal.ts
@@ -161,11 +161,16 @@ function dimensionOf(bot: Bot): string {
   return bot.game.dimension;
 }
 
+function isNether(dim: string): boolean {
+  return dim === "the_nether" || dim === "minecraft:the_nether";
+}
+
+function isOverworld(dim: string): boolean {
+  return dim === "overworld" || dim === "minecraft:overworld";
+}
+
 export async function returnThroughPortal(bot: Bot): Promise<string> {
-  // mineflayer's Dimension type is never "minecraft:"-prefixed (index.d.ts:482:
-  // 'the_nether' | 'overworld' | 'the_end'), so checking for a prefixed variant
-  // here was dead code masking an impossible comparison.
-  if (dimensionOf(bot) !== "the_nether") {
+  if (!isNether(dimensionOf(bot))) {
     return "Not in the Nether — nothing to return from.";
   }
   const portal = bot.findBlock({ matching: (b) => b.name === "nether_portal", maxDistance: 64 });
@@ -181,7 +186,7 @@ export async function returnThroughPortal(bot: Bot): Promise<string> {
 
   // Standing in the portal is what triggers the transition; give it time.
   await new Promise((r) => setTimeout(r, 6000));
-  const home = dimensionOf(bot) === "overworld";
+  const home = isOverworld(dimensionOf(bot));
   return home ? "Returned to the overworld." : "Stood in the portal but did not transition.";
 }
 

--- a/src/skills/setup-stash.ts
+++ b/src/skills/setup-stash.ts
@@ -94,7 +94,10 @@ export const setupStashSkill: Skill = {
       // fall through and place an additional chest (stash expansion).
       let hasRoom = true;
       try {
-        const chest = await bot.openContainer(existingChest);
+        const chest = (await Promise.race([
+          bot.openContainer(existingChest),
+          new Promise((_, rej) => setTimeout(() => rej(new Error("openContainer timeout")), 10000)),
+        ])) as Awaited<ReturnType<typeof bot.openContainer>>;
         const containerSlots = chest.inventoryStart;
         const used = chest.containerItems().length;
         hasRoom = used < containerSlots;

--- a/src/stream/tts.ts
+++ b/src/stream/tts.ts
@@ -75,7 +75,18 @@ function discardTTS(): void {
   ttsInstance = null;
 }
 
-let audioCounter = 0;
+let audioCounter = (() => {
+  try {
+    const existing = fs
+      .readdirSync(AUDIO_DIR)
+      .filter((f) => f.startsWith("thought-") && f.endsWith(".mp3"))
+      .map((f) => parseInt(f.replace(/\D/g, ""), 10))
+      .filter((n) => !isNaN(n));
+    return existing.length ? Math.max(...existing) : 0;
+  } catch {
+    return 0;
+  }
+})();
 
 /**
  * Only one synthesis runs at a time.
@@ -150,7 +161,11 @@ export async function generateSpeech(text: string): Promise<string | null> {
     const files = fs
       .readdirSync(AUDIO_DIR)
       .filter((f) => f.startsWith("thought-") && f.endsWith(".mp3"))
-      .sort();
+      .sort((a, b) => {
+        const numA = parseInt(a.replace(/\D/g, ""), 10) || 0;
+        const numB = parseInt(b.replace(/\D/g, ""), 10) || 0;
+        return numA - numB;
+      });
     while (files.length > 10) {
       const old = files.shift()!;
       fs.unlinkSync(path.join(AUDIO_DIR, old));


### PR DESCRIPTION
- **Fixed TTS audio file pruning and counter desync in `src/stream/tts.ts`:**
  - *Why*: JavaScript's default `Array.prototype.sort()` sorts strings lexicographically. When `audioCounter` started at 0 and generated low-indexed files like `thought-1.mp3` while legacy files like `thought-99990.mp3` existed, `thought-1.mp3` sorted to the beginning of the list. The retention loop (`files.shift()`) immediately deleted the freshly generated audio file before the browser overlay could play it, causing 404 errors. I updated the cleanup to sort files numerically by their index and initialized `audioCounter` to the maximum existing index found in `AUDIO_DIR` on startup.

- **Fixed `fill_bucket` pre-execution failure and false blacklisting in `src/skills/fill-bucket.ts`:**
  - *Why*: `fillBucketSkill.estimateMaterials` previously returned `{ bucket: 1 }`. When `runSkill` executed, `gatherMaterials` attempted to verify or craft a bucket. Because `"bucket"` does not exist in `materials.ts`'s `MINE_SOURCES` or `CRAFT_TREE`, `gatherMaterials` failed whenever the bot did not strictly hold an empty item named `"bucket"` (including when already holding a `lava_bucket` or `water_bucket`). This returned a `Skill fill_bucket failed:` error, which triggered `isSkillCrash` in `memory.ts` and permanently blacklisted `fill_bucket` after 5 attempts without ever running `fillBucketSkill.execute`. I changed `estimateMaterials` to return `{}` so the skill handles its own prerequisites through `bucketPlan`.

- **Included equipped armor slots in `src/skills/craft-gear.ts`:**
  - *Why*: The `owned` items check read from `bot.inventory.items()`, which in Mineflayer returns only inventory slots 9–44 and excludes equipped armor in slots 5–8. When a bot was already wearing an `iron_chestplate`, `owned.includes("iron_chestplate")` evaluated to `false`. This led `affordableArmourPiece` to repeatedly craft duplicate chestplates whenever iron was available instead of progressing to leggings, boots, and helmets. I changed the check to inspect all inventory slots (`bot.inventory.slots`), ensuring worn armor is properly recognized.

- **Added namespaced dimension support to `src/skills/nether-portal.ts`:**
  - *Why*: On Minecraft 1.21.4 Paper servers, packet dimension identifiers are sent with namespaces (`"minecraft:the_nether"` and `"minecraft:overworld"`). `returnThroughPortal` strictly checked for `"the_nether"` and `"overworld"`, causing it to immediately abort with `"Not in the Nether — nothing to return from."` while standing inside the Nether. I added `isNether` and `isOverworld` helpers that match both bare and namespaced dimension identifiers.

- **Added position and type null-guards in perception, actions, brain, and place-guard:**
  - *Why*: During death/respawn sequences or when new entity instances enter the world before coordinate sync packets arrive, `entity.position` or `bot.entity` is null or undefined. Calls in `distTo`, `getNearbyEntities`, `scanHostiles`, `flee`, and `attackNearest` called `.distanceTo()` on undefined objects, throwing uncaught `TypeError` exceptions that crashed decision loops and interval timers. Additionally, `place-guard.ts` threw if non-string values were passed to `isFurniture`. I added null-checks across all entity distance lookups and supported `block` and `item` parameter fallbacks for `place_block` and `mine_block`.

- **Added 10-second timeout race to `openContainer` in `src/skills/setup-stash.ts`:**
  - *Why*: If an existing stash chest was obstructed or out of interaction reach, calling `bot.openContainer(existingChest)` without a timeout race caused the Promise to hang indefinitely, blocking the bot until the global 240-second skill watchdog aborted the process. I wrapped the call in a 10-second `Promise.race` timeout consistent with `stash.ts` and `smelt-ores.ts`.

- **Added `pale_oak_door` to `DOOR_TYPES` in `src/skills/build-house.ts`:**
  - *Why*: Minecraft 1.21.4 introduced Pale Garden biomes with `pale_oak_log` and `pale_oak_planks`. When a bot harvested pale oak wood, `craftDoors` and subsequent door placement failed because `pale_oak_door` was missing from `DOOR_TYPES`. I added `"pale_oak_door"` to the supported door list.

- **Memoized `descendantCount` in `src/bot/advancement-tree.ts`:**
  - *Why*: `descendantCount` was executing recursive subtree traversals on every comparator call inside `byUnlockValue` during advancement routing sorts. Because the advancement tree graph is static at runtime, I memoized the counts in a `DESCENDANT_COUNTS` Map to make lookups O(1) and reduce CPU overhead on decision cycles.