### PR TITLE
docs: document core module APIs

### DIFF
--- a/src/bot/actions.ts
+++ b/src/bot/actions.ts
@@ -1,3 +1,16 @@
+/**
+ * Built-in action dispatch for decisions produced by the LLM.
+ *
+ * @remarks
+ * `executeAction` is the public boundary. It applies the direct-action
+ * watchdog, delegates registered skills to the skill executor, and converts
+ * runtime failures into short strings the brain can reason about. To add a
+ * built-in action, add a case to `executeActionInner`, validate/default its
+ * parameters there, expose its name through the appropriate role's
+ * `allowedActions`, and cover the result in `actions.test.ts`. Multi-step work
+ * that needs material gathering, progress, or cancellation belongs in a
+ * `Skill` instead of this dispatcher.
+ */
 import type { Bot } from "mineflayer";
 import pkg from "mineflayer-pathfinder";
 const { goals, Movements } = pkg;
@@ -18,6 +31,7 @@ import { config } from "../config.js";
 
 import { STASH_POS } from "./role.js";
 import { baseMoves, safeMoves, explorerMoves, safeGoto, collectNearbyDrops, bumpNavGeneration } from "./navigation.js";
+/** Re-exported navigation helpers used by actions and skill implementations. */
 export { safeMoves, explorerMoves, safeGoto, collectNearbyDrops };
 
 /** Hard cap for a single DIRECT action. Longer than any legit action (gather
@@ -26,7 +40,10 @@ export { safeMoves, explorerMoves, safeGoto, collectNearbyDrops };
 const DIRECT_ACTION_TIMEOUT_MS = 150_000;
 
 /**
- * Watchdog wrapper around the action dispatcher. Direct actions (mine_block,
+ * Executes one built-in action or registered skill and returns a message for
+ * the decision loop.
+ *
+ * Direct actions (mine_block,
  * go_to, gather_wood, eat, …) call unbounded `bot.dig`/`goto`/`consume` that can
  * block a bot's ENTIRE brain loop forever if the server never responds — Forge
  * froze 50 min mid-`mine_block` (its `bot.dig` never returned) because, unlike
@@ -34,6 +51,12 @@ const DIRECT_ACTION_TIMEOUT_MS = 150_000;
  * hard timeout that stops movement + digging so the brain always recovers.
  * invoke_skill / registered-skill names are left to runSkill's own 240s watchdog
  * (double-bounding would preempt legit long skills like build_house).
+ *
+ * @param bot - The Mineflayer bot that owns the action and navigation state.
+ * @param action - A built-in action name, `invoke_skill`, or registered skill name.
+ * @param params - LLM-supplied action parameters; each action validates its own fields.
+ * @returns A user-facing success, refusal, timeout, or failure message. Expected
+ * failures are represented as strings rather than thrown into the brain loop.
  */
 export async function executeAction(bot: Bot, action: string, params: Record<string, any>): Promise<string> {
   const delegatesToSkill = action === "invoke_skill" || skillRegistry.get(action) !== undefined;
@@ -785,8 +808,15 @@ async function scatterSaplings(bot: Bot, max: number): Promise<number> {
  *  "ore" matches any *_ore through the branch below, so an unspecified dig now
  *  follows the intent the logs actually show. A bot that wants stone still says
  *  so, and one did. */
+/** Fallback matcher requested when the LLM asks to mine without naming a block. */
 export const DEFAULT_MINE_TARGET = "ore";
 
+/**
+ * Builds the name predicate used by mining actions.
+ *
+ * @param blockType - A concrete Minecraft block name or the `ore` category.
+ * @returns A predicate plus whether the request should use ore-specific logic.
+ */
 export function blockMatcher(blockType: string): { match: (name: string) => boolean; isOre: boolean } {
   const bt = blockType.toLowerCase();
   if (bt === "ore" || bt === "ores") {

--- a/src/bot/perception.ts
+++ b/src/bot/perception.ts
@@ -1,9 +1,29 @@
+/**
+ * Converts live Mineflayer state into compact text consumed by the decision
+ * prompts.
+ *
+ * @remarks
+ * Extend perception by deriving a bounded signal from the bot, then appending
+ * one concise line to `parts` in `getWorldContext`. Keep scans small because
+ * this function runs in the decision loop. Add globally interesting blocks to
+ * `NOTABLE_BLOCKS`; add entity families through `HOSTILE_MOBS` or
+ * `PASSIVE_MOBS`. New wording should be covered in `perception.test.ts` because
+ * it becomes part of the model's behavioral contract.
+ */
 import type { Bot } from "mineflayer";
 import type { Entity } from "prismarine-entity";
 import { recordOre } from "./memory.js";
 import { miningReachLine, bestPickaxeName } from "./mining-reach.js";
 import { undergroundNote } from "./underground.js";
 
+/**
+ * Builds the newline-delimited world snapshot supplied to the LLM.
+ *
+ * @param bot - Bot whose position, vitals, inventory, entities, and blocks are read.
+ * @param role - Optional role name used to make underground guidance role-aware.
+ * @returns Stable, human-readable context with urgent warnings included only
+ * when their conditions are present.
+ */
 export function getWorldContext(bot: Bot, role?: string): string {
   const pos = bot.entity.position;
   const health = bot.health;
@@ -181,10 +201,12 @@ function entityName(entity: Entity): string {
   }
 }
 
+/** Returns whether an entity's canonical Mineflayer name is a hostile mob. */
 export function isHostile(entity: Entity): boolean {
   return HOSTILE_MOBS.has(entityName(entity));
 }
 
+/** Returns whether an entity's canonical Mineflayer name is a passive mob. */
 export function isPassive(entity: Entity): boolean {
   return PASSIVE_MOBS.has(entityName(entity));
 }

--- a/src/bot/role.ts
+++ b/src/bot/role.ts
@@ -1,3 +1,16 @@
+/**
+ * Static role definitions for every bot in the swarm.
+ *
+ * @remarks
+ * Add a role by defining a complete `BotRoleConfig`, assigning non-conflicting
+ * viewer/overlay ports and memory file, then adding it to `BOT_ROSTER`.
+ * `allowedActions` and `allowedSkills` are prompt capabilities rather than a
+ * security boundary, so the corresponding dispatcher or skill must already be
+ * registered. Keep shared coordinates in exported constants so every role and
+ * skill uses the same location.
+ */
+
+/** Configuration injected into bot startup, prompts, memory, and role policy. */
 export interface BotRoleConfig {
   /** Display name, e.g. "Atlas" */
   name: string;
@@ -299,4 +312,5 @@ export const BLADE_CONFIG: BotRoleConfig = {
 };
 
 /** All bot configs in startup order. */
+/** Ordered startup roster; adding a role config elsewhere does not start it. */
 export const BOT_ROSTER: BotRoleConfig[] = [ATLAS_CONFIG, FLORA_CONFIG, FORGE_CONFIG, MASON_CONFIG, BLADE_CONFIG];

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1,3 +1,17 @@
+/**
+ * Public LLM query facade for strategic, reactive, critic, legacy decision,
+ * and conversational calls.
+ *
+ * @remarks
+ * Decision queries build role-specific prompts, call the configured provider,
+ * and normalize output through `extractJSON` and `parseDecision` before it
+ * reaches the action dispatcher. `extractJSON` removes thinking/code fences,
+ * finds the first balanced object, and attempts to close truncated objects.
+ * The legacy `queryLLM` path retries one short response with a smaller fallback
+ * prompt; other query paths return conservative fallbacks on errors. Add a new
+ * decision query by reusing these normalization helpers so aliases, parameter
+ * hoisting, JSON repair, and failure behavior remain consistent.
+ */
 import { chat } from "./provider.js";
 import { config } from "../config.js";
 import { getSkillPromptLines } from "../skills/registry.js";
@@ -24,12 +38,14 @@ function thinkFor(model: string): boolean | "low" | "medium" | "high" {
 
 const llmLog = createLogger();
 
+/** Tool schema that can be rendered into an LLM prompt. */
 export interface LLMTool {
   name: string;
   description: string;
   parameters: Record<string, { type: string; description: string }>;
 }
 
+/** Provider-neutral chat message used by all query functions. */
 export interface LLMMessage {
   role: "system" | "user" | "assistant";
   content: string;
@@ -38,7 +54,12 @@ export interface LLMMessage {
 // ─── JSON extraction helpers ────────────────────────────────────────────────
 // Shared across all query functions to handle LLM output quirks.
 
-/** Extract the first complete JSON object from an LLM response string. */
+/**
+ * Extracts the first complete JSON object from an LLM response string.
+ * Thinking tags and Markdown fences are removed first. If output is truncated,
+ * a trailing partial field is discarded and missing closing braces are added;
+ * unrecoverable text returns `null` instead of reaching `JSON.parse`.
+ */
 function extractJSON(raw: string): string | null {
   let content = raw.trim();
   content = content.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
@@ -221,6 +242,12 @@ function parseDecision(
 /**
  * Strategic decision — uses the strong model (32b) for goal-setting.
  * Called infrequently (~every 10s or on goal complete).
+ *
+ * @param context - Current world snapshot from perception.
+ * @param recentMessages - Recent decision history; only the last four are used.
+ * @param memoryContext - Long-term bot memory to prepend when present.
+ * @param role - Role prompt context and allowed capabilities.
+ * @returns A normalized action decision; provider errors fall back to `idle`.
  */
 export async function queryStrategic(
   context: string,
@@ -288,6 +315,11 @@ export async function queryStrategic(
  * Reactive decision — uses the fast model (8b) for urgent responses.
  * Called when hostiles spotted, damage taken, health/hunger critical.
  * Tiny prompt, fast response.
+ *
+ * @param name - Bot display name used in the reactive system prompt.
+ * @param situation - Concise urgent event description.
+ * @param allowedActions - Optional role-specific actions exposed to the model.
+ * @returns A normalized urgent decision; provider errors fall back to `flee`.
  */
 export async function queryReactive(
   name: string,
@@ -328,6 +360,11 @@ export async function queryReactive(
 /**
  * Critic — verifies action results and suggests next step.
  * Uses fast model. Called after every action completes.
+ *
+ * @param name - Bot display name used in the critic prompt.
+ * @param actionContext - Completed action and observed result to evaluate.
+ * @param allowedActions - Optional actions the critic may recommend next.
+ * @returns The verdict, normalized follow-up action, and goal-completion flag.
  */
 export async function queryCritic(
   name: string,
@@ -484,6 +521,14 @@ DYNAMIC SKILLS: ${(() => {
 /**
  * Legacy query — still used by old code paths.
  * Uses the FAST model (8b) for quick decisions.
+ * A short or empty response is retried once with a compact fallback prompt;
+ * provider or parsing failures return an `idle` decision.
+ *
+ * @param context - Current decision context.
+ * @param recentMessages - Conversation history included without truncation.
+ * @param memoryContext - Optional remembered facts to prepend to the request.
+ * @param roleConfig - Optional legacy role and capability configuration.
+ * @returns A repaired and normalized action decision.
  */
 export async function queryLLM(
   context: string,
@@ -552,6 +597,14 @@ export async function queryLLM(
   }
 }
 
+/**
+ * Produces short conversational text without action JSON parsing.
+ *
+ * @param prompt - Player message or conversational instruction.
+ * @param context - World and role context for the chat prompt.
+ * @param roleConfig - Optional bot identity.
+ * @returns Thinking tags removed from provider text, or a short fallback on error.
+ */
 export async function chatWithLLM(prompt: string, context: string, roleConfig?: { name: string }): Promise<string> {
   try {
     const response = await chat({

--- a/src/skills/executor.ts
+++ b/src/skills/executor.ts
@@ -1,3 +1,15 @@
+/**
+ * Runtime lifecycle for `Skill` implementations from `types.ts`.
+ *
+ * @remarks
+ * A skill declares metadata, material estimates, and an abort-aware `execute`
+ * method. `runSkill` serializes work per bot, gathers materials, forwards
+ * progress, and races execution against `skill.timeoutMs` or the 240-second
+ * default. `abortActiveSkill` signals cooperative cancellation; the watchdog
+ * additionally stops navigation and digging so a hung await cannot freeze the
+ * brain. New skills should honor `AbortSignal`, bound internal phases, return a
+ * `SkillResult`, and be registered in `registry.ts`.
+ */
 import type { Bot } from "mineflayer";
 import type { Skill, SkillProgress, SkillResult } from "./types.js";
 import { gatherMaterials } from "./materials.js";
@@ -6,6 +18,7 @@ import { recordSkillAttempt } from "../bot/memory.js";
 import { getBotMemoryStore, registerBotMemory } from "../bot/memory-registry.js";
 import { bumpNavGeneration } from "../bot/navigation.js";
 
+/** Associates a bot with its memory store before skill execution begins. */
 export { registerBotMemory };
 
 type ActiveSkillState = {
@@ -40,14 +53,21 @@ export function takeSkillOutcome(bot: Bot, skillName: string): boolean | undefin
   return rec.success;
 }
 
+/** Returns whether this bot currently owns an active skill execution slot. */
 export function isSkillRunning(bot: Bot): boolean {
   return activeSkillMap.has(bot);
 }
 
+/** Returns the active skill name for a bot, or `null` when it is idle. */
 export function getActiveSkillName(bot: Bot): string | null {
   return activeSkillMap.get(bot)?.skill.name ?? null;
 }
 
+/**
+ * Requests cooperative cancellation of the bot's active skill.
+ * The skill must observe its `AbortSignal`; timeout cleanup separately handles
+ * stuck navigation and digging calls.
+ */
 export function abortActiveSkill(bot: Bot): void {
   const active = activeSkillMap.get(bot);
   if (active) {
@@ -59,6 +79,12 @@ export function abortActiveSkill(bot: Bot): void {
 /**
  * Run a skill to completion: gather materials → execute → return result string.
  * Called from executeAction() when the LLM picks a skill action.
+ *
+ * @param bot - Bot that owns the single active execution slot.
+ * @param skill - Registered skill implementing the interface in `types.ts`.
+ * @param params - LLM-provided parameters passed to estimation and execution.
+ * @returns A concise result message for the brain; expected failures and
+ * crashes are recorded and converted to messages.
  */
 export async function runSkill(bot: Bot, skill: Skill, params: Record<string, any>): Promise<string> {
   const active = activeSkillMap.get(bot);


### PR DESCRIPTION
Closes #13.

Adds source JSDoc for extending actions, perception, roles, LLM queries, and skill execution, including JSON repair, retry fallbacks, cancellation, and timeouts.

Validation: build, typecheck, 580 tests, ESLint, and Prettier pass.
