### PR TITLE
feat: hot-reload skills during development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ npm test        # Run tests
 npm run build   # Type-check and compile
 ```
 
+`npm run dev` reloads TypeScript, Voyager, and generated skills without
+restarting the process. If an edited skill does not compile or parse, the last
+working version remains registered.
+
 ## How to Contribute
 
 ### Reporting Bugs

--- a/README.md
+++ b/README.md
@@ -538,10 +538,14 @@ minecraft-agent-swarm/
 ## Development
 
 ```bash
-npm run dev     # Run with tsx watch (hot reload)
+npm run dev     # Watch source and hot-reload individual skills
 npm test        # Run tests
 npm run build   # Compile TypeScript
 ```
+
+Skill edits under `src/skills`, `skills/voyager`, and `skills/generated` are
+reloaded without restarting the process. Invalid edits leave the last working
+skill registered.
 
 ### Adding a New TypeScript Skill
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "typecheck": "tsc --noEmit",
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --exclude \"src/skills/**\" --exclude \"skills/voyager/**\" --exclude \"skills/generated/**\" src/index.ts --hot-reload-skills",
     "start": "tsx --max-old-space-size=8192 src/index.ts",
     "server": "cd server && java -Xmx2G -Xms1G -jar paper.jar --nogui",
     "download-skills": "node scripts/download-voyager-skills.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { startUnifiedViewer } from "./stream/unified-viewer.js";
 import { abortActiveSkill, getActiveSkillName } from "./skills/executor.js";
 import type { Bot } from "mineflayer";
 import { assertProviderConfigured } from "./llm/provider.js";
+import { startSkillHotReload } from "./skills/hot-reload.js";
 
 /** Live bot handles, so the heap guard can abort a runaway skill. */
 const LIVE_BOTS = new Map<string, Bot>();
@@ -16,6 +17,9 @@ loadDynamicSkills();
 
 // Registry of active bot stop functions for clean multi-bot shutdown
 const activeStops: (() => void)[] = [];
+if (process.argv.includes("--hot-reload-skills")) {
+  activeStops.push(startSkillHotReload());
+}
 
 function shutdownAll() {
   console.log("\n[Main] Shutting down all bots...");

--- a/src/skills/dynamic-loader.test.ts
+++ b/src/skills/dynamic-loader.test.ts
@@ -86,3 +86,28 @@ test("dynamic-loader: a finished skill leaves no watchdog timer behind", async (
   fs.unlinkSync(skillPath);
   skillRegistry.delete("testQuick");
 });
+
+for (const directory of ["generated", "voyager"]) {
+  test(`dynamic-loader: ${directory} reload keeps the previous skill after a syntax error`, async () => {
+    const { reloadDynamicSkill } = await import("./dynamic-loader.js");
+    const { skillRegistry } = await import("./registry.js");
+    const skillName = `hotReload${directory}`;
+    const skillPath = path.join(__dirname, `../../skills/${directory}/${skillName}.js`);
+
+    fs.writeFileSync(skillPath, `async function ${skillName}(bot) { bot.version = 1; }`);
+    reloadDynamicSkill(skillPath);
+    const workingSkill = skillRegistry.get(skillName)!;
+
+    fs.writeFileSync(skillPath, `async function ${skillName}( {`);
+    assert.throws(() => reloadDynamicSkill(skillPath), SyntaxError);
+    assert.equal(skillRegistry.get(skillName), workingSkill);
+
+    fs.writeFileSync(skillPath, `async function ${skillName}(bot) { bot.version = 2; }`);
+    reloadDynamicSkill(skillPath);
+    assert.notEqual(skillRegistry.get(skillName), workingSkill);
+
+    fs.unlinkSync(skillPath);
+    reloadDynamicSkill(skillPath);
+    assert.equal(skillRegistry.has(skillName), false);
+  });
+}

--- a/src/skills/dynamic-loader.ts
+++ b/src/skills/dynamic-loader.ts
@@ -15,6 +15,7 @@ const SKILL_DIRS = [path.join(PROJECT_ROOT, "skills/voyager"), path.join(PROJECT
 // All Voyager skills concatenated — used as a helper library in the vm context so skills
 // can call each other (e.g. smeltFiveRawIron calls craftFurnace, placeItem, smeltItem)
 let voyagerHelperBundle = "";
+const voyagerSources = new Map<string, string>();
 
 // Primitive functions that Voyager skills expect in the global scope.
 // These are the Voyager framework utilities, implemented with Mineflayer's API.
@@ -179,18 +180,21 @@ export function loadDynamicSkills(): void {
   // Build the Voyager helper bundle first (all Voyager skills concatenated)
   // so that when any skill runs it can call helpers like craftFurnace, placeItem, smeltItem
   const voyagerDir = SKILL_DIRS[0];
+  voyagerSources.clear();
   if (fs.existsSync(voyagerDir)) {
-    const parts: string[] = [];
     for (const file of fs.readdirSync(voyagerDir)) {
       if (!file.endsWith(".js")) continue;
       try {
-        parts.push(fs.readFileSync(path.join(voyagerDir, file), "utf-8"));
-      } catch {
-        /* skip unreadable files */
+        const filePath = path.join(voyagerDir, file);
+        const code = fs.readFileSync(filePath, "utf-8");
+        new vm.Script(code);
+        voyagerSources.set(filePath, code);
+      } catch (err: any) {
+        console.warn(`[DynamicSkill] Skipped ${file}: ${err.message}`);
       }
     }
-    voyagerHelperBundle = parts.join("\n\n");
   }
+  rebuildVoyagerHelperBundle();
 
   for (const dir of SKILL_DIRS) {
     if (!fs.existsSync(dir)) continue;
@@ -207,6 +211,41 @@ export function loadDynamicSkills(): void {
     }
   }
   if (loaded > 0) console.log(`[DynamicSkill] Loaded ${loaded} dynamic skills`);
+}
+
+function rebuildVoyagerHelperBundle(): void {
+  voyagerHelperBundle = Array.from(voyagerSources.values()).join("\n\n");
+}
+
+/**
+ * Atomically reload one Voyager or generated JavaScript skill.
+ * The existing registry entry and helper source stay live if parsing fails.
+ */
+export function reloadDynamicSkill(filePath: string): string {
+  const resolvedPath = path.resolve(filePath);
+  const parentDir = path.dirname(resolvedPath);
+  if (!SKILL_DIRS.includes(parentDir) || path.extname(resolvedPath) !== ".js") {
+    throw new Error(`Not a dynamic skill path: ${filePath}`);
+  }
+
+  const skillName = path.basename(resolvedPath, ".js");
+  if (!fs.existsSync(resolvedPath)) {
+    skillRegistry.delete(skillName);
+    voyagerSources.delete(resolvedPath);
+    rebuildVoyagerHelperBundle();
+    return skillName;
+  }
+
+  // Build and parse everything before mutating shared state. A broken edit
+  // therefore leaves the last working skill and Voyager helper bundle intact.
+  const nextSkill = buildDynamicSkill(skillName, resolvedPath);
+  const nextSource = fs.readFileSync(resolvedPath, "utf-8");
+  if (parentDir === SKILL_DIRS[0]) {
+    voyagerSources.set(resolvedPath, nextSource);
+    rebuildVoyagerHelperBundle();
+  }
+  skillRegistry.set(skillName, nextSkill);
+  return skillName;
 }
 
 function buildDynamicSkill(name: string, filePath: string): Skill {

--- a/src/skills/hot-reload.test.ts
+++ b/src/skills/hot-reload.test.ts
@@ -1,0 +1,76 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { reloadTypeScriptSkills, startSkillHotReload } from "./hot-reload.js";
+import { reloadDynamicSkill } from "./dynamic-loader.js";
+import { skillRegistry } from "./registry.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "../../");
+
+async function waitFor(check: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for skill reload");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+test("TypeScript reload replaces valid skills and keeps the previous version on failure", async () => {
+  const skillName = `hot_reload_ts_${process.pid}`;
+  const filePath = path.join(__dirname, `hot-reload-fixture-${process.pid}.ts`);
+  const moduleSource = (version: number) => `
+    export const fixtureSkill = {
+      name: "${skillName}",
+      description: "test fixture",
+      params: {},
+      estimateMaterials: () => ({}),
+      execute: async () => ({ success: true, message: "v${version}" }),
+    };
+  `;
+
+  try {
+    fs.writeFileSync(filePath, moduleSource(1));
+    assert.deepEqual(await reloadTypeScriptSkills(filePath), [skillName]);
+    const first = skillRegistry.get(skillName)!;
+
+    fs.writeFileSync(filePath, "export const fixtureSkill = {");
+    await assert.rejects(reloadTypeScriptSkills(filePath));
+    assert.equal(skillRegistry.get(skillName), first);
+
+    fs.writeFileSync(filePath, moduleSource(2));
+    await reloadTypeScriptSkills(filePath);
+    const second = skillRegistry.get(skillName)!;
+    assert.notEqual(second, first);
+    assert.equal((await second.execute({} as any, {}, new AbortController().signal, () => {})).message, "v2");
+  } finally {
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    skillRegistry.delete(skillName);
+  }
+});
+
+test("development watcher reloads generated skills without restarting", async () => {
+  const skillName = `hotReloadWatch${process.pid}`;
+  const filePath = path.join(PROJECT_ROOT, "skills/generated", `${skillName}.js`);
+  const stop = startSkillHotReload(PROJECT_ROOT);
+
+  try {
+    fs.writeFileSync(filePath, `async function ${skillName}(bot) { bot.version = 1; }`);
+    await waitFor(() => skillRegistry.has(skillName));
+    const first = skillRegistry.get(skillName)!;
+
+    fs.writeFileSync(filePath, `async function ${skillName}(bot) { bot.version = 2; }`);
+    await waitFor(() => skillRegistry.get(skillName) !== first);
+    const second = skillRegistry.get(skillName)!;
+
+    fs.writeFileSync(filePath, `async function ${skillName}( {`);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.equal(skillRegistry.get(skillName), second);
+  } finally {
+    stop();
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    reloadDynamicSkill(filePath);
+  }
+});

--- a/src/skills/hot-reload.ts
+++ b/src/skills/hot-reload.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { reloadDynamicSkill } from "./dynamic-loader.js";
+import { skillRegistry } from "./registry.js";
+import type { Skill } from "./types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "../../");
+let importSequence = 0;
+
+function isSkill(value: unknown): value is Skill {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<Skill>;
+  return (
+    typeof candidate.name === "string" &&
+    typeof candidate.description === "string" &&
+    typeof candidate.estimateMaterials === "function" &&
+    typeof candidate.execute === "function"
+  );
+}
+
+/** Reload all `Skill` exports from one TypeScript module as one registry update. */
+export async function reloadTypeScriptSkills(filePath: string): Promise<string[]> {
+  const specifier = `${pathToFileURL(filePath).href}?hot=${Date.now()}-${importSequence++}`;
+  const module = await import(specifier);
+  const skills = Object.values(module).filter(isSkill);
+  const names = skills.map((skill) => skill.name);
+
+  if (new Set(names).size !== names.length) {
+    throw new Error(`Duplicate skill names exported by ${path.basename(filePath)}`);
+  }
+
+  // Import and validate every export before replacing anything. Running skills
+  // retain their old object; future invocations read the new registry entries.
+  for (const skill of skills) skillRegistry.set(skill.name, skill);
+  return names;
+}
+
+type PendingReload = { timer: ReturnType<typeof setTimeout>; kind: "typescript" | "dynamic" };
+
+/** Starts granular skill watchers used by `npm run dev`; returns their cleanup. */
+export function startSkillHotReload(projectRoot: string = PROJECT_ROOT): () => void {
+  const watchers: fs.FSWatcher[] = [];
+  const pending = new Map<string, PendingReload>();
+
+  const schedule = (filePath: string, kind: "typescript" | "dynamic") => {
+    const previous = pending.get(filePath);
+    if (previous) clearTimeout(previous.timer);
+
+    const timer = setTimeout(async () => {
+      pending.delete(filePath);
+      try {
+        const names = kind === "typescript" ? await reloadTypeScriptSkills(filePath) : [reloadDynamicSkill(filePath)];
+        if (names.length > 0) {
+          console.log(`[SkillHotReload] Reloaded ${names.join(", ")} from ${path.relative(projectRoot, filePath)}`);
+        }
+      } catch (err) {
+        console.warn(
+          `[SkillHotReload] Kept previous skill after ${path.relative(projectRoot, filePath)} failed: ${(err as Error).message}`,
+        );
+      }
+    }, 75);
+    pending.set(filePath, { timer, kind });
+  };
+
+  const watchDirectory = (dir: string, kind: "typescript" | "dynamic") => {
+    if (!fs.existsSync(dir)) return;
+    watchers.push(
+      fs.watch(dir, (_event, filename) => {
+        if (!filename) return;
+        const name = filename.toString();
+        if (kind === "typescript") {
+          if (!name.endsWith(".ts") || name.endsWith(".test.ts") || name === "hot-reload.ts") return;
+        } else if (!name.endsWith(".js")) {
+          return;
+        }
+        schedule(path.join(dir, name), kind);
+      }),
+    );
+  };
+
+  watchDirectory(path.join(projectRoot, "src/skills"), "typescript");
+  watchDirectory(path.join(projectRoot, "skills/voyager"), "dynamic");
+  watchDirectory(path.join(projectRoot, "skills/generated"), "dynamic");
+  console.log(`[SkillHotReload] Watching ${watchers.length} skill directories`);
+
+  return () => {
+    for (const { timer } of pending.values()) clearTimeout(timer);
+    pending.clear();
+    for (const watcher of watchers) watcher.close();
+  };
+}


### PR DESCRIPTION
Closes #16.

`npm run dev` now keeps the process alive while reloading changed TypeScript, Voyager, and generated skills individually. A reload validates the complete replacement before updating the registry, so syntax or compilation failures leave the last working skill active.

The existing source watcher still restarts the process for changes outside skill directories.

Validation:
- `npm test` (584 tests)
- `npm run build`
- `npm run typecheck`
- `npm run lint` (0 errors; 30 pre-existing warnings)
- `npm run format:check`
